### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ apt-forktracer (0.8) UNRELEASED; urgency=medium
   * Set debhelper-compat version in Build-Depends.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.4.1, no changes needed.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Apr 2020 13:52:53 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
 Build-Depends: debhelper-compat (= 12), python3, dh-python
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Homepage: http://owsiany.pl/apt-forktracer-page
 Vcs-Git: https://github.com/porridge/apt-forktracer.git
 Vcs-Browser: https://github.com/porridge/apt-forktracer


### PR DESCRIPTION
Fix some issues reported by lintian
* Bump debhelper from old 9 to 12. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version.html))
* Set debhelper-compat version in Build-Depends. ([uses-debhelper-compat-file](https://lintian.debian.org/tags/uses-debhelper-compat-file.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Update standards version to 4.4.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/apt-forktracer/9c00db00-38ed-42c4-aebe-2ca2b0dc0914.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/9c00db00-38ed-42c4-aebe-2ca2b0dc0914/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9c00db00-38ed-42c4-aebe-2ca2b0dc0914/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9c00db00-38ed-42c4-aebe-2ca2b0dc0914/diffoscope)).
