### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apt-forktracer (0.10) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 06 Sep 2022 17:17:31 -0000
+
 apt-forktracer (0.9) unstable; urgency=medium
 
   * Version bump only, just to be able to do a source-only upload.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ apt-forktracer (0.10) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
   * Bump debhelper from old 12 to 13.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 06 Sep 2022 17:17:31 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 apt-forktracer (0.10) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 06 Sep 2022 17:17:31 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
 Build-Depends: debhelper-compat (= 13), python3, dh-python
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Homepage: https://owsiany.pl/apt-forktracer-page
 Vcs-Git: https://github.com/porridge/apt-forktracer.git
 Vcs-Browser: https://github.com/porridge/apt-forktracer

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
 Build-Depends: debhelper-compat (= 12), python3, dh-python
 Standards-Version: 4.5.1
-Homepage: http://owsiany.pl/apt-forktracer-page
+Homepage: https://owsiany.pl/apt-forktracer-page
 Vcs-Git: https://github.com/porridge/apt-forktracer.git
 Vcs-Browser: https://github.com/porridge/apt-forktracer
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: apt-forktracer
 Section: admin
 Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
-Build-Depends: debhelper-compat (= 12), python3, dh-python
+Build-Depends: debhelper-compat (= 13), python3, dh-python
 Standards-Version: 4.5.1
 Homepage: https://owsiany.pl/apt-forktracer-page
 Vcs-Git: https://github.com/porridge/apt-forktracer.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/apt-forktracer/1ef5815b-bb21-4d6c-8dc5-084fd72b579d.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Homepage: [-http&#8203;://owsiany.pl/apt-forktracer-page-] {+https&#8203;://owsiany.pl/apt-forktracer-page+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1ef5815b-bb21-4d6c-8dc5-084fd72b579d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1ef5815b-bb21-4d6c-8dc5-084fd72b579d/diffoscope)).
